### PR TITLE
Replace coronasafe references

### DIFF
--- a/docs/ayushma/getting-started/contribution-guidelines.md
+++ b/docs/ayushma/getting-started/contribution-guidelines.md
@@ -25,7 +25,7 @@ Ayushma is an open-source project and welcomes contributions from the community 
 
 ### Additional Resources
 
-* [Ayushma GitHub Repository](https://github.com/coronasafe/ayushma\_fe)
+* [Ayushma GitHub Repository](https://github.com/ohcnetwork/ayushma\_fe)
 * [Open Health Care Network](https://ohc.network/)
 
 We appreciate your contributions to making Ayushma a valuable tool for improving healthcare accessibility!

--- a/docs/ayushma/getting-started/installation.md
+++ b/docs/ayushma/getting-started/installation.md
@@ -14,7 +14,7 @@ This section outlines the installation process for both the Ayushma front-end an
 1. **Clone the Repository:** Open a terminal or command prompt and navigate to the directory where you want to install Ayushma. Then, clone the repository using the following command:
 
 ```
-git clone https://github.com/coronasafe/ayushma_fe.git
+git clone https://github.com/ohcnetwork/ayushma_fe.git
 ```
 
 1. **Navigate to the Project Directory:**

--- a/docs/care/apps/scribe/index.md
+++ b/docs/care/apps/scribe/index.md
@@ -7,7 +7,7 @@
 | **Title**         | Care Scribe Feature Overview, Integration, and Operation |
 | **App Namespace** | `care_scribe`                                            |
 | **Last-Modified** | 2024-05-07                                               |
-| **Github-Repo**   | https://github.com/coronasafe/care_scribe                        |
+| **Github-Repo**   | https://github.com/ohcnetwork/care_scribe                |
 | **Created**       | 2024-04-15                                               |
 
 ## Introduction

--- a/docs/leaderboard/gsoc-2024/github-discussion.md
+++ b/docs/leaderboard/gsoc-2024/github-discussion.md
@@ -3,7 +3,7 @@
 ## Implementation Details
 
 ### Code Structure
-- Pull Request Link : [Link](https://github.com/coronasafe/leaderboard/pull/463)
+- Pull Request Link : [Link](https://github.com/ohcnetwork/leaderboard/pull/463)
 - The codebase is organized into the following files:
 
 ### Files

--- a/docs/leaderboard/gsoc-2024/gsoc-2024.md
+++ b/docs/leaderboard/gsoc-2024/gsoc-2024.md
@@ -4,7 +4,7 @@
 
 ## Objective
 
-The [Google Summer of Code 2024 Project for Leaderboard](https://github.com/coronasafe/leaderboard/issues/212) aims to integrate GitHub Discussions into the leaderboard. To achieve this, we need to scrape GitHub discussions using the GitHub API. However, the current Python scraper relies on the REST API, whereas GitHub Discussions can only be fetched using the GraphQL API. Additionally, Python does not natively support GraphQL integration as outlined [here](https://github.com/orgs/community/discussions/4327).
+The [Google Summer of Code 2024 Project for Leaderboard](https://github.com/ohcnetwork/leaderboard/issues/212) aims to integrate GitHub Discussions into the leaderboard. To achieve this, we need to scrape GitHub discussions using the GitHub API. However, the current Python scraper relies on the REST API, whereas GitHub Discussions can only be fetched using the GraphQL API. Additionally, Python does not natively support GraphQL integration as outlined [here](https://github.com/orgs/community/discussions/4327).
 
 ---
 

--- a/docs/leaderboard/gsoc-2024/refactor-scraper.md
+++ b/docs/leaderboard/gsoc-2024/refactor-scraper.md
@@ -19,13 +19,13 @@ Run the following command inside the `scraper` directory:
 pnpm dev org_name data_dir [date] [num_days]
 ```
 **Example :** 
-1. pnpm dev coronasafe data-repo/github 
-2. pnpm dev coronasafe data-repo/github 2024-07-21 30
+1. pnpm dev ohcnetwork data-repo/github 
+2. pnpm dev ohcnetwork data-repo/github 2024-07-21 30
 ---
 ## Implementation Details
 
 ### Code Structure
-- Pull Request Link : [Link](https://github.com/coronasafe/leaderboard/pull/458)
+- Pull Request Link : [Link](https://github.com/ohcnetwork/leaderboard/pull/458)
 - The scraper code is divided into nine different files, which are stored inside `scraper/src/github-scraper`.
 
 ### Files

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -27,11 +27,11 @@ const config: Config = {
       {
         docs: {
           sidebarPath: "./sidebars.ts",
-          editUrl: "https://github.com/coronasafe/docs/tree/master/",
+          editUrl: "https://github.com/ohcnetwork/docs/tree/master/",
         },
         blog: {
           showReadingTime: true,
-          editUrl: "https://github.com/coronasafe/docs/tree/master/",
+          editUrl: "https://github.com/ohcnetwork/docs/tree/master/",
         },
         theme: {
           customCss: "./src/css/custom.css",
@@ -72,7 +72,7 @@ const config: Config = {
         { to: "/docs/leaderboard/", label: "Leaderboard", position: "left" },
         { to: "/blog", label: "Blog", position: "left" },
         {
-          href: 'https://github.com/coronasafe/docs',
+          href: 'https://github.com/ohcnetwork/docs',
           position: 'right',
           className: 'header-github-link',
           'aria-label': 'GitHub repository',

--- a/src/pages/index.md
+++ b/src/pages/index.md
@@ -32,13 +32,13 @@ CARE is a centralized capacity management and patient management system which is
 
 The journey of the Open Healthcare Network is a testament to the power of community collaboration and open-source development for public good. What began as a response to the COVID-19 pandemic has evolved into a comprehensive hospital management system operational across 11 Indian states, directly benefiting over 186.8 million people. The system, seamlessly integrated across 581 hospitals, has facilitated medical attention to 362,349 patients and enabled over half a million consultations via 1,884 dedicated health workers.
 
-Main Repositories: [Backend](https://github.com/coronasafe/care) |
-[Frontend](https://github.com/coronasafe/care_fe) |
-[Dashboard](https://github.com/coronasafe/care_dashboard) |
-[Middleware for Device Integration](https://github.com/coronasafe/teleicu_middleware) |
-[Image Processing](https://github.com/coronasafe/care_ocr) |
-[Contributors](https://github.com/coronasafe/leaderboard)
+Main Repositories: [Backend](https://github.com/ohcnetwork/care) |
+[Frontend](https://github.com/ohcnetwork/care_fe) |
+[Dashboard](https://github.com/ohcnetwork/care_dashboard) |
+[Middleware for Device Integration](https://github.com/ohcnetwork/teleicu_middleware) |
+[Image Processing](https://github.com/ohcnetwork/care_ocr) |
+[Contributors](https://github.com/ohcnetwork/leaderboard)
 
-Deploy Docs: [AWS](https://deploydocs.coronasafe.network/cloud-deployment-overview/aws) | [Azure](https://deploydocs.coronasafe.network/cloud-deployment-overview/azure) | [GCP](https://deploydocs.coronasafe.network/cloud-deployment-overview/gcp)
+Deploy Docs: [AWS](https://deploydocs.ohc.network/cloud-deployment-overview/aws) | [Azure](https://deploydocs.ohc.network/cloud-deployment-overview/azure) | [GCP](https://deploydocs.ohc.network/cloud-deployment-overview/gcp)
 
 Our Student Contributors: [Students](https://contributors.ohc.network/) | [Leaderboard](https://contributors.ohc.network/leaderboard)


### PR DESCRIPTION
broken links: https://deploydocs.ohc.network/*